### PR TITLE
Add Gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: composer install && composer test

--- a/README.md
+++ b/README.md
@@ -74,7 +74,25 @@ All validating methods:
 - `Isbn::validateAsIbsn13`
 - `Isbn::validateAsEan13`
 
-## Test
+## Development
+
+### Using Gitpod
+
+You can start a dev environnement by clicking 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/biblys/isbn)
+and start hacking in your browser right away!
+
+### Locally
+
+If you'd rather setup a local dev environnement, you'll need:
+
+- PHP 7.x
+- Composer
+- (Optional) Docker to run tests and debug against different version of PHP
+
+Clone this repository and run `composer install` to get started!
+
+## Tests
 
 Run tests with PHPUnit:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Latest Stable Version](https://poser.pugx.org/biblys/isbn/v/stable)](https://packagist.org/packages/biblys/isbn)
 [![Total Downloads](https://poser.pugx.org/biblys/isbn/downloads)](https://packagist.org/packages/biblys/isbn)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/biblys/isbn)
 
 biblys/isbn can be used to:
 


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitLab, GitHub, and Bitbucket that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.