### PR TITLE
Add parse method

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ All validating methods:
 
 [Learn more about validating ISBNs](https://github.com/biblys/isbn/wiki/Validating-ISBNs-using-the-new-public-API)
 
+### Parse
+
+Use case: extracting the publisher code from an ISBN.
+
+```php
+<?php
+use Biblys\Isbn\Isbn;
+
+$input = "9782956420132";
+$isbn = Isbn::parse($input);
+echo $isbn->getRegistrantElement(); // Prints "9564201"
+
+```
+
+`Isbn::parse` returns a `ParsedIsbn` object implementing the following methods:
+- `ParsedIsbn->getGs1Element`:: EAN product code
+- `ParsedIsbn->getRegistrationGroupElement`: Country, geographical region or language aera code
+- `ParsedIsbn->getRegistrantElement`: Publisher (or imprint within a group) code
+- `ParsedIsbn->getPublicationElement`: Publication code
+- `ParsedIsbn->getCheckDigit`: Checksum used for validation
+
+
 ## Development
 
 ### Using Gitpod

--- a/src/Biblys/Isbn/Formatter.php
+++ b/src/Biblys/Isbn/Formatter.php
@@ -14,61 +14,76 @@ namespace Biblys\Isbn;
 
 class Formatter
 {
+    /**
+     * @throws IsbnParsingException
+     */
     public static function formatAsIsbn10(string $input): string
     {
         $parsedInput = Parser::parse($input);
-        $countryCode = $parsedInput["countryCode"];
-        $publisherCode = $parsedInput["publisherCode"];
-        $publicationCode = $parsedInput["publicationCode"];
+        $countryCode = $parsedInput->getRegistrationGroupElement();
+        $publisherCode = $parsedInput->getRegistrantElement();
+        $publicationCode = $parsedInput->getPublicationElement();
         $checksum = self::_calculateChecksumForIsbn10Format($countryCode, $publisherCode, $publicationCode);
 
         return "$countryCode-$publisherCode-$publicationCode-$checksum";
     }
 
+    /**
+     * @throws IsbnParsingException
+     */
     public static function formatAsIsbn13(string $input): string
     {
         $parsedInput = Parser::parse($input);
-        $productCode = $parsedInput["productCode"];
-        $countryCode = $parsedInput["countryCode"];
-        $publisherCode = $parsedInput["publisherCode"];
-        $publicationCode = $parsedInput["publicationCode"];
+        $productCode = $parsedInput->getGs1Element();
+        $countryCode = $parsedInput->getRegistrationGroupElement();
+        $publisherCode = $parsedInput->getRegistrantElement();
+        $publicationCode = $parsedInput->getPublicationElement();
         $checksum = self::_calculateChecksumForIsbn13Format($productCode, $countryCode, $publisherCode, $publicationCode);
 
         return "$productCode-$countryCode-$publisherCode-$publicationCode-$checksum";
     }
 
+    /**
+     * @throws IsbnParsingException
+     */
     public static function formatAsIsbnA(string $input): string
     {
         $doiPrefix = "10";
         $parsedInput = Parser::parse($input);
-        $productCode = $parsedInput["productCode"];
-        $countryCode = $parsedInput["countryCode"];
-        $publisherCode = $parsedInput["publisherCode"];
-        $publicationCode = $parsedInput["publicationCode"];
+        $productCode = $parsedInput->getGs1Element();
+        $countryCode = $parsedInput->getRegistrationGroupElement();
+        $publisherCode = $parsedInput->getRegistrantElement();
+        $publicationCode = $parsedInput->getPublicationElement();
         $checksum = self::_calculateChecksumForIsbn13Format($productCode, $countryCode, $publisherCode, $publicationCode);
 
         return "$doiPrefix.$productCode.$countryCode$publisherCode/$publicationCode$checksum";
     }
 
+    /**
+     * @throws IsbnParsingException
+     */
     public static function formatAsEan13(string $input): string
     {
         $parsedInput = Parser::parse($input);
-        $productCode = $parsedInput["productCode"];
-        $countryCode = $parsedInput["countryCode"];
-        $publisherCode = $parsedInput["publisherCode"];
-        $publicationCode = $parsedInput["publicationCode"];
+        $productCode = $parsedInput->getGs1Element();
+        $countryCode = $parsedInput->getRegistrationGroupElement();
+        $publisherCode = $parsedInput->getRegistrantElement();
+        $publicationCode = $parsedInput->getPublicationElement();
         $checksum = self::_calculateChecksumForIsbn13Format($productCode, $countryCode, $publisherCode, $publicationCode);
 
         return $productCode . $countryCode . $publisherCode . $publicationCode . $checksum;
     }
 
+    /**
+     * @throws IsbnParsingException
+     */
     public static function formatAsGtin14(string $input, int $prefix): string
     {
         $parsedInput = Parser::parse($input);
-        $productCode = $parsedInput["productCode"];
-        $countryCode = $parsedInput['countryCode'];
-        $publisherCode = $parsedInput['publisherCode'];
-        $publicationCode = $parsedInput['publicationCode'];
+        $productCode = $parsedInput->getGs1Element();
+        $countryCode = $parsedInput->getRegistrationGroupElement();
+        $publisherCode = $parsedInput->getRegistrantElement();
+        $publicationCode = $parsedInput->getPublicationElement();
 
         $productCodeWithPrefix = $prefix . $productCode;
         $checksum = self::_calculateChecksumForIsbn13Format($productCodeWithPrefix, $countryCode, $publisherCode, $publicationCode);

--- a/src/Biblys/Isbn/Isbn.php
+++ b/src/Biblys/Isbn/Isbn.php
@@ -201,11 +201,11 @@ class Isbn
 
         try {
             $parsedCode = Parser::parse($code);
-            $this->_gs1productCode = $parsedCode["productCode"];
-            $this->_countryCode = $parsedCode["countryCode"];
-            $this->_isbnAgencyCode = $parsedCode["agencyCode"];
-            $this->_publisherCode = $parsedCode["publisherCode"];
-            $this->_publicationCode = $parsedCode["publicationCode"];
+            $this->_gs1productCode = $parsedCode->getGs1Element();
+            $this->_countryCode = $parsedCode->getRegistrationGroupElement();
+            $this->_isbnAgencyCode = $parsedCode->getRegistrationAgencyName();
+            $this->_publisherCode = $parsedCode->getRegistrantElement();
+            $this->_publicationCode = $parsedCode->getPublicationElement();
         } catch (IsbnParsingException $exception) {
             // FIXME in next major version (breaking change)
             // For backward compatibility reason, instanciating should not throw

--- a/src/Biblys/Isbn/Isbn.php
+++ b/src/Biblys/Isbn/Isbn.php
@@ -183,6 +183,19 @@ class Isbn
         }
     }
 
+    /**
+     * Returns a parsed isbn
+     *
+     * @param string $input A string to be parsed as an ISBN
+     *
+     * @return ParsedIsbn the parsed isbn object
+     * @throws IsbnParsingException
+     */
+    static public function parse(string $input): ParsedIsbn
+    {
+        return Parser::parse($input);
+    }
+
     /* Legacy non static properties and methods (backward compatibility) */
     // FIXME: deprecate and remove on next major version
 

--- a/src/Biblys/Isbn/Isbn.php
+++ b/src/Biblys/Isbn/Isbn.php
@@ -208,8 +208,16 @@ class Isbn
     private $_checksumCharacter;
     private $_gtin14Prefix;
 
+    /**
+     * @deprecated
+     */
     public function __construct($code = null)
     {
+        trigger_error(
+            "Instantiating the Isbn class is deprecated and will be removed in the future. Learn more: https://git.io/JqRgc",
+            E_USER_DEPRECATED
+        );
+
         $this->_input = $code;
 
         try {
@@ -221,7 +229,7 @@ class Isbn
             $this->_publicationCode = $parsedCode->getPublicationElement();
         } catch (IsbnParsingException $exception) {
             // FIXME in next major version (breaking change)
-            // For backward compatibility reason, instanciating should not throw
+            // For backward compatibility reason, instantiating should not throw
         }
     }
 

--- a/src/Biblys/Isbn/ParsedIsbn.php
+++ b/src/Biblys/Isbn/ParsedIsbn.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the biblys/isbn package.
+ *
+ * (c) Clément Bourgoin
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+
+namespace Biblys\Isbn;
+
+class ParsedIsbn
+{
+  // ISBN Users' Manual, International Edition, p. 11-12
+  // https://www.kb.se/download/18.71dda82e160c04f1cc412bc/1531827912246/ISBN%20International%20Users%20Manual%20-%207th%20edition.pdf
+  private $_gs1Element = "978";
+  private $_registrationGroupElement = "";
+  private $_registrantElement = "";
+  private $_publicationElement = "";
+  private $_registrationAgencyName = "";
+
+  public function __construct(array $elements)
+  {
+    $this->_gs1Element = $elements["gs1Element"];
+    $this->_registrationGroupElement = $elements["registrationGroupElement"];
+    $this->_registrantElement = $elements["registrantElement"];
+    $this->_publicationElement = $elements["publicationElement"];
+    $this->_registrationAgencyName = $elements["registrationAgencyName"];
+  }
+
+  public function getGs1Element(): string
+  {
+    return $this->_gs1Element;
+  }
+
+  public function getRegistrationGroupElement(): string
+  {
+    return $this->_registrationGroupElement;
+  }
+
+  public function getRegistrantElement(): string
+  {
+    return $this->_registrantElement;
+  }
+
+  public function getPublicationElement(): string
+  {
+    return $this->_publicationElement;
+  }
+
+  public function getRegistrationAgencyName(): string
+  {
+    return $this->_registrationAgencyName;
+  }
+}

--- a/src/Biblys/Isbn/Parser.php
+++ b/src/Biblys/Isbn/Parser.php
@@ -22,7 +22,7 @@ class Parser
         ERROR_INVALID_COUNTRY_CODE = 'Country code is unknown',
         ERROR_CANNOT_MATCH_RANGE = "Cannot find any ISBN range matching prefix %s";
 
-    public static function parse($input)
+    public static function parse(string $input): ParsedIsbn
     {
         if (empty($input)) {
             throw new IsbnParsingException(static::ERROR_EMPTY);
@@ -48,13 +48,13 @@ class Parser
         $publisherCode = $result[1];
         $publicationCode = $result[2];
 
-        return [
-            "productCode" => $productCode,
-            "countryCode" => $countryCode,
-            "agencyCode" => $agencyCode,
-            "publisherCode" => $publisherCode,
-            "publicationCode" => $publicationCode,
-        ];
+        return new ParsedIsbn([
+            "gs1Element" => $productCode,
+            "registrationGroupElement" => $countryCode,
+            "registrationAgencyName" => $agencyCode,
+            "registrantElement" => $publisherCode,
+            "publicationElement" => $publicationCode,
+        ]);
     }
 
     private static function _stripHyphens($input)
@@ -69,12 +69,12 @@ class Parser
     {
         $length = strlen($input);
 
-        if ($length == 13 || $length == 10) {
-            $input = substr_replace($input, "", -1);
+        if ($length == 12 || $length == 9) {
             return $input;
         }
 
-        if ($length == 12 || $length == 9) {
+        if ($length == 13 || $length == 10) {
+            $input = substr_replace($input, "", -1);
             return $input;
         }
 

--- a/tests/deprecated/constructorTest.php
+++ b/tests/deprecated/constructorTest.php
@@ -21,6 +21,22 @@ use PHPUnit\Framework\TestCase;
 
 class testConstructor extends TestCase
 {
+    protected function setUp(): void
+    {
+        PHPUnit\Framework\Error\Deprecated::$enabled = false;
+    }
+
+    public function testDeprecatedNotice()
+    {
+        PHPUnit\Framework\Error\Deprecated::$enabled = true;
+        $this->expectException('PHPUnit\Framework\Error\Deprecated');
+        $this->expectExceptionMessage(
+            "Instantiating the Isbn class is deprecated and will be removed in the future. Learn more: https://git.io/JqRgc"
+        );
+
+        $isbn = new Isbn('9782207258040');
+    }
+
     /**
      * Non-regression test for Github issue #5
      * https://github.com/biblys/isbn/pull/5

--- a/tests/deprecated/formatTest.php
+++ b/tests/deprecated/formatTest.php
@@ -28,13 +28,14 @@ class testFormatIsbn extends TestCase
 
     public function testDeprecatedNotice()
     {
-        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $this->expectException('PHPUnit\Framework\Error\Deprecated');
         $this->expectExceptionMessage(
             "Isbn->format is deprecated and will be removed in the future. Use the Isbn::convertToIsbn13 method instead. Learn more: https://git.io/JtAEx"
         );
 
         $isbn = new Isbn('9782207258040');
+
+        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $isbn->format('ISBN-13');
     }
 

--- a/tests/deprecated/getErrorsTest.php
+++ b/tests/deprecated/getErrorsTest.php
@@ -23,13 +23,14 @@ class testGetErrors extends TestCase
 {
     public function testDeprecatedNotice()
     {
-        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $this->expectException('PHPUnit\Framework\Error\Deprecated');
         $this->expectExceptionMessage(
             "Isbn->getErrors is deprecated and will be removed in the future. Use Isbn::validateAs… methods instead. Learn more: https://git.io/JtAEx"
         );
 
         $isbn = new Isbn("6897896354577");
+
+        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $isbn->getErrors();
     }
 

--- a/tests/deprecated/isValidTest.php
+++ b/tests/deprecated/isValidTest.php
@@ -28,14 +28,14 @@ class testIsbnIsValid extends TestCase
 
     public function testDeprecationNotice(): void
     {
-        PHPUnit\Framework\Error\Deprecated::$enabled = true;
-
         $this->expectException('PHPUnit\Framework\Error\Deprecated');
         $this->expectExceptionMessage(
             "Isbn->isValid is deprecated and will be removed in the future. Use Isbn::validateAs… methods instead. Learn more: https://git.io/JtAEx"
         );
 
         $isbn = new Isbn('9782207258040');
+
+        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $isbn->isValid();
     }
 

--- a/tests/deprecated/validateTest.php
+++ b/tests/deprecated/validateTest.php
@@ -28,13 +28,14 @@ class testValidateIsbn extends TestCase
 
     public function testDeprecatedNotice(): void
     {
-        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $this->expectException('PHPUnit\Framework\Error\Deprecated');
         $this->expectExceptionMessage(
             "Isbn->validate is deprecated and will be removed in the future. Use Isbn::validateAs… methods instead. Learn more: https://git.io/JtAEx"
         );
 
         $isbn = new Isbn('9782843449499');
+
+        PHPUnit\Framework\Error\Deprecated::$enabled = true;
         $isbn->validate();
     }
 

--- a/tests/parseTest.php
+++ b/tests/parseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the biblys/isbn package.
+ *
+ * (c) Clément Bourgoin
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Biblys\Isbn\Isbn;
+use PHPUnit\Framework\TestCase;
+
+class testParse extends TestCase
+{
+  public function testParseIsbn()
+  {
+    $isbn = Isbn::parse("9782207258040");
+
+    $this->assertInstanceOf("Biblys\Isbn\ParsedIsbn", $isbn);
+  }
+
+  public function testGetGs1Element()
+  {
+    $isbn = Isbn::parse("9782207258040");
+
+    $this->assertEquals("978", $isbn->getGs1Element());
+  }
+
+  public function testGetRegistrationGroupElement()
+  {
+    $isbn = Isbn::parse("9782207258040");
+
+    $this->assertEquals("2", $isbn->getRegistrationGroupElement());
+  }
+
+  public function testGetRegistrantElement()
+  {
+    $isbn = Isbn::parse("9782207258040");
+
+    $this->assertEquals("207", $isbn->getRegistrantElement());
+  }
+
+  public function testGetPublicationElement()
+  {
+    $isbn = Isbn::parse("9782207258040");
+
+    $this->assertEquals("25804", $isbn->getPublicationElement());
+  }
+
+  public function testGetRegistrationAgencyName()
+  {
+    $isbn = Isbn::parse("9782207258040");
+
+    $this->assertEquals("French language", $isbn->getRegistrationAgencyName());
+  }
+}


### PR DESCRIPTION
The goal of this PR is to add an `ISBN::parse` public method that will return `ParsedIsbn` object implementing the following methods:

- `ParsedIsbn->getGs1Element`
- `ParsedIsbn->getRegistrationGroupElement`
- `ParsedIsbn->getRegistrantElement`
- `ParsedIsbn->getPublicationElement`
- `ParsedIsbn->getCheckDigit`

Source: [ISBN Users' Manual, International Edition, p. 11-12](https://www.kb.se/download/18.71dda82e160c04f1cc412bc/1531827912246/ISBN%20International%20Users%20Manual%20-%207th%20edition.pdf)

## TODO

- [x] Implement `parse` method
- [x] Refactor Parser class
- [x] Add deprecation notices
- [x] Add documentation to README
